### PR TITLE
Fix bugs

### DIFF
--- a/src/composer/lookup.rs
+++ b/src/composer/lookup.rs
@@ -100,7 +100,7 @@ impl<F: Field> Composer<F> {
                 sorted_values[col].extend(lookups.iter().map(|&i| table.columns[col][i]));
             }
             for col in table.width..sorted_values.len() {
-                sorted_values[col].extend(vec![F::zero(); table.size]);
+                sorted_values[col].extend(vec![F::zero(); lookups.len()]);
             }
         }
 

--- a/src/composer/mod.rs
+++ b/src/composer/mod.rs
@@ -154,6 +154,7 @@ impl<F: Field> Composer<F> {
             prover_key.insert(&format!("sigma_{}", col), sigma.clone());
         }
 
+        // the last column for table indices
         let table_values = self.compute_table_values();
         for (col, table_value) in table_values.iter().enumerate() {
             prover_key.insert(&format!("table_{}", col), table_value.clone());

--- a/src/composer/range.rs
+++ b/src/composer/range.rs
@@ -6,7 +6,8 @@ use crate::{Error, Field};
 use super::{Composer, Variable};
 
 impl<F: Field> Composer<F> {
-    /// num_bits has to be even
+    /// here we enforce range constraint by quads (2-bit unit), so `num_bits` must be even.
+    /// The quads are orgnized in the big-endian order
     pub fn enforce_range(&mut self, var: Variable, num_bits: usize) -> Result<usize, Error> {
         assert!(!self.is_finalized);
         assert!(self.program_width >= 4);
@@ -158,14 +159,6 @@ mod tests {
         assert_eq!(cs.wires["w_1"], vec![Variable(0), Variable(5), Variable(0)]);
         assert_eq!(cs.wires["w_2"], vec![Variable(2), Variable(6), Variable(0)]);
         assert_eq!(cs.wires["w_3"], vec![Variable(3), Variable(7), Variable(0)]);
-
-        for j in 0..4 {
-            let label = format!("w_{}", j);
-            print!("\n{}:", label);
-            for w in cs.wires[&label].iter() {
-                print!("\n{}", cs.assignments[w.0])
-            }
-        }
 
         Ok(())
     }

--- a/src/prover/widget/arithmetic.rs
+++ b/src/prover/widget/arithmetic.rs
@@ -90,23 +90,13 @@ impl<F: Field, D: Domain<F>> Widget<F, D> for ArithmeticWidget<F, D> {
             terms.push((q_arith_zeta * w_zeta, q));
         }
 
-        let alpha = prover.get_challenge("alpha")?;
         let lc = LinearCombination::new("arithmetic", terms);
 
+        let alpha = prover.get_challenge("alpha")?;
         *combinator *= alpha;
 
         Ok((lc, F::zero()))
     }
-}
-
-#[inline]
-fn term<F: Field, D: Domain<F>>(
-    prover: &mut Prover<F, D>,
-    index: usize,
-    q_arith_zeta: F,
-) -> Result<(F, String), Error> {
-    let w_zeta = prover.evaluate(&format!("w_{}", index), "zeta")?;
-    Ok((q_arith_zeta * w_zeta, format!("q_{}", index)))
 }
 
 #[cfg(test)]
@@ -153,6 +143,7 @@ mod tests {
         print!("compute quotient...");
         prover.add_challenge("alpha", Fr::rand(rng));
         let mut quotient = vec![Fr::zero(); prover.coset_size()];
+        // the combinator for arithmetic widget has to be one, due to the presence of the public input.
         widget.compute_quotient_contribution(&mut prover, &mut Fr::one(), &mut quotient)?;
         let p = DensePolynomial::from_coefficients_vec(prover.coset.coset_ifft(&quotient));
         let (_, remainder) = p.divide_by_vanishing_poly(prover.domain).unwrap();

--- a/src/prover/widget/lookup.rs
+++ b/src/prover/widget/lookup.rs
@@ -379,7 +379,7 @@ mod tests {
         print!("compute quotient...");
         prover.add_challenge("alpha", Fr::rand(rng));
         let mut quotient = vec![Fr::zero(); prover.coset_size()];
-        let mut combinator = Fr::one();
+        let mut combinator = prover.get_challenge("alpha")?;
         widget.compute_quotient_contribution(&mut prover, &mut combinator, &mut quotient)?;
         let vi = prover.get_coset_values("vi")?;
         cfg_iter_mut!(quotient)
@@ -394,7 +394,7 @@ mod tests {
         let zeta = Fr::rand(rng);
         prover.add_challenge("zeta", zeta);
         prover.add_challenge("zeta_omega", zeta * prover.domain.generator());
-        let mut combinator = Fr::one();
+        let mut combinator = prover.get_challenge("alpha")?;
         let (r, complement) = widget.compute_linear_contribution(&mut prover, &mut combinator)?;
         println!("done");
 

--- a/src/prover/widget/lookup.rs
+++ b/src/prover/widget/lookup.rs
@@ -26,11 +26,11 @@ impl<F: Field, D: Domain<F>> LookupWidget<F, D> {
                 .into_iter()
                 .map(|i| format!("w_{}", i))
                 .collect(),
-            table_column_labels: (0..program_width)
+            table_column_labels: (0..program_width + 1)
                 .into_iter()
                 .map(|i| format!("table_{}", i))
                 .collect(),
-            sorted_list_labels: (0..program_width)
+            sorted_list_labels: (0..program_width + 1)
                 .into_iter()
                 .map(|i| format!("s_{}", i))
                 .collect(),
@@ -70,14 +70,13 @@ impl<F: Field, D: Domain<F>> Widget<F, D> for LookupWidget<F, D> {
             let n = prover.domain_size();
             let t: Vec<_> = cfg_into_iter!((0..n))
                 .map(|i| {
-                    let t = combine(
+                    combine(
                         eta,
                         self.table_column_labels
                             .iter()
                             .map(|l| values[l][i])
                             .collect(),
-                    );
-                    eta * t + values["q_table"][i]
+                    )
                 })
                 .collect();
             let v: Vec<_> = cfg_into_iter!((0..n))
@@ -85,14 +84,17 @@ impl<F: Field, D: Domain<F>> Widget<F, D> for LookupWidget<F, D> {
                     if values["q_lookup"][i].is_zero() {
                         F::zero()
                     } else {
-                        let v =
-                            combine(eta, self.wire_labels.iter().map(|l| values[l][i]).collect());
-                        (eta * v + values["q_table"][i]) * values["q_lookup"][i]
+                        let v = combine(
+                            eta,
+                            self.wire_labels
+                                .iter()
+                                .chain(vec!["q_table".to_string()].iter())
+                                .map(|l| values[l][i])
+                                .collect(),
+                        );
+                        v * values["q_lookup"][i]
                     }
                 })
-                .collect();
-            let s: Vec<_> = cfg_into_iter!((0..n))
-                .map(|i| eta * values["s"][i] + values["q_table"][i])
                 .collect();
 
             let beta_gamma_factor = (beta + F::one()) * gamma;
@@ -101,7 +103,8 @@ impl<F: Field, D: Domain<F>> Widget<F, D> for LookupWidget<F, D> {
             z.push(acc);
             cfg_into_iter!(0..(n - 1)).for_each(|i| {
                 let numerator = (v[i] + gamma) * (t[i] + beta * t[i + 1] + beta_gamma_factor);
-                let denominator = gamma * (s[i] + beta * s[i + 1] + beta_gamma_factor);
+                let denominator =
+                    gamma * (values["s"][i] + beta * values["s"][i + 1] + beta_gamma_factor);
                 acc *= numerator * denominator.inverse().unwrap();
                 z.push(acc);
             });
@@ -130,24 +133,26 @@ impl<F: Field, D: Domain<F>> Widget<F, D> for LookupWidget<F, D> {
         let n = quotient.len();
         let t: Vec<_> = cfg_into_iter!((0..n))
             .map(|i| {
-                let t = combine(
+                combine(
                     eta,
                     self.table_column_labels
                         .iter()
                         .map(|l| values[l][i])
                         .collect(),
-                );
-                eta * t + values["q_table"][i]
+                )
             })
             .collect();
         let v: Vec<_> = cfg_into_iter!((0..n))
             .map(|i| {
-                let v = combine(eta, self.wire_labels.iter().map(|l| values[l][i]).collect());
-                (eta * v + values["q_table"][i]) * values["q_lookup"][i]
+                combine(
+                    eta,
+                    self.wire_labels
+                        .iter()
+                        .chain(vec!["q_table".to_string()].iter())
+                        .map(|l| values[l][i])
+                        .collect(),
+                )
             })
-            .collect();
-        let s: Vec<_> = cfg_into_iter!((0..n))
-            .map(|i| eta * values["s"][i] + values["q_table"][i])
             .collect();
 
         let beta_gamma_factor = (beta + F::one()) * gamma;
@@ -159,11 +164,13 @@ impl<F: Field, D: Domain<F>> Widget<F, D> for LookupWidget<F, D> {
             } else {
                 i + self.program_width
             };
+
             let numerator = values["z_lookup"][i]
-                * (v[i] + gamma)
+                * (values["q_lookup"][i] * v[i] + gamma)
                 * (t[i] + beta * t[next_i] + beta_gamma_factor);
-            let denominator =
-                values["z_lookup"][next_i] * gamma * (s[i] + beta * s[next_i] + beta_gamma_factor);
+            let denominator = values["z_lookup"][next_i]
+                * gamma
+                * (values["s"][i] + beta * values["s"][next_i] + beta_gamma_factor);
 
             quotient[i] += *combinator
                 * (numerator - denominator
@@ -189,18 +196,18 @@ impl<F: Field, D: Domain<F>> Widget<F, D> for LookupWidget<F, D> {
         let w_zeta = self
             .wire_labels
             .iter()
+            .chain(vec!["q_table".to_string()].iter())
             .map(|l| prover.evaluate(l, "zeta"))
             .collect::<Result<Vec<_>, Error>>()?;
         let q_loolup_zeta = prover.evaluate("q_lookup", "zeta")?;
-        let q_table_zeta = prover.evaluate("q_table", "zeta")?;
-        let q_table_zeta_omega = prover.evaluate("q_table", "zeta_omega")?;
+
         let s_zeta_omega = prover.evaluate("s", "zeta_omega")?;
         let z_lookup_zeta_omega = prover.evaluate("z_lookup", "zeta_omega")?;
 
         let table_lc = {
             let mut etas = Vec::with_capacity(self.program_width);
             let mut acc = F::one();
-            for _ in 0..self.program_width {
+            for _ in 0..self.program_width + 1 {
                 etas.push(acc);
                 acc *= eta;
             }
@@ -224,13 +231,12 @@ impl<F: Field, D: Domain<F>> Widget<F, D> for LookupWidget<F, D> {
             .evaluate_lagrange_polynomial(prover.domain_size(), &zeta);
 
         let numerator = {
-            let v_zeta = eta * combine(eta, w_zeta) + q_table_zeta;
-            let t_zeta = eta * table_zeta + q_table_zeta;
-            let t_zeta_omega = eta * table_zeta_omega + q_table_zeta_omega;
+            let v_zeta = combine(eta, w_zeta);
 
-            (q_loolup_zeta * v_zeta + gamma) * (t_zeta + beta * t_zeta_omega + beta_gamma_factor)
+            (q_loolup_zeta * v_zeta + gamma)
+                * (table_zeta + beta * table_zeta_omega + beta_gamma_factor)
         };
-        let denominator = z_lookup_zeta_omega * gamma * eta;
+        let denominator = z_lookup_zeta_omega * gamma;
 
         let lc = LinearCombination::new(
             "lookup",
@@ -243,11 +249,7 @@ impl<F: Field, D: Domain<F>> Widget<F, D> for LookupWidget<F, D> {
             ],
         );
         let complement = *combinator
-            * (z_lookup_zeta_omega
-                * gamma
-                * (q_table_zeta
-                    + beta * (q_table_zeta_omega + eta * s_zeta_omega)
-                    + beta_gamma_factor)
+            * (z_lookup_zeta_omega * gamma * (beta * s_zeta_omega + beta_gamma_factor)
                 + alpha * lagrange_1_zeta
                 + alpha_2 * lagrange_n_zeta);
 
@@ -330,38 +332,35 @@ mod tests {
                 let shifted_omega = omega * prover.domain.generator();
 
                 let w_omega = {
-                    let mut v = eta * polys["w_3"].evaluate(&omega) + polys["w_2"].evaluate(&omega);
+                    let mut v =
+                        eta * polys["q_table"].evaluate(&omega) + polys["w_3"].evaluate(&omega);
+                    v = eta * v + polys["w_2"].evaluate(&omega);
                     v = eta * v + polys["w_1"].evaluate(&omega);
                     v = eta * v + polys["w_0"].evaluate(&omega);
-                    v = eta * v + polys["q_table"].evaluate(&omega);
+
                     v
                 };
+
                 let table_omega = {
                     let mut v =
-                        eta * polys["table_3"].evaluate(&omega) + polys["table_2"].evaluate(&omega);
+                        eta * polys["table_4"].evaluate(&omega) + polys["table_3"].evaluate(&omega);
+                    v = eta * v + polys["table_2"].evaluate(&omega);
                     v = eta * v + polys["table_1"].evaluate(&omega);
                     v = eta * v + polys["table_0"].evaluate(&omega);
-                    v = eta * v + polys["q_table"].evaluate(&omega);
 
                     v
                 };
                 let table_shifted_omega = {
-                    let mut v = eta * polys["table_3"].evaluate(&shifted_omega)
-                        + polys["table_2"].evaluate(&shifted_omega);
+                    let mut v = eta * polys["table_4"].evaluate(&shifted_omega)
+                        + polys["table_3"].evaluate(&shifted_omega);
+                    v = eta * v + polys["table_2"].evaluate(&shifted_omega);
                     v = eta * v + polys["table_1"].evaluate(&shifted_omega);
                     v = eta * v + polys["table_0"].evaluate(&shifted_omega);
-                    v = eta * v + polys["q_table"].evaluate(&shifted_omega);
 
                     v
                 };
-                let s_omega = {
-                    let s = polys["s"].evaluate(&omega);
-                    s * eta + polys["q_table"].evaluate(&omega)
-                };
-                let s_shifted_omega = {
-                    let s = polys["s"].evaluate(&shifted_omega);
-                    s * eta + polys["q_table"].evaluate(&shifted_omega)
-                };
+                let s_omega = polys["s"].evaluate(&omega);
+                let s_shifted_omega = polys["s"].evaluate(&shifted_omega);
 
                 let numerator = polys["z_lookup"].evaluate(&omega)
                     * (polys["q_lookup"].evaluate(&omega) * w_omega + gamma)

--- a/src/prover/widget/permutation.rs
+++ b/src/prover/widget/permutation.rs
@@ -206,7 +206,7 @@ impl<F: Field, D: Domain<F>> Widget<F, D> for PermutationWidget<F, D> {
 mod tests {
 
     use ark_bn254::Fr;
-    use ark_ff::{One, Zero};
+    use ark_ff::Zero;
     use ark_poly::{univariate::DensePolynomial, EvaluationDomain, UVPolynomial};
     use ark_std::{cfg_iter_mut, test_rng, UniformRand};
 
@@ -290,7 +290,8 @@ mod tests {
         print!("compute quotient...");
         prover.add_challenge("alpha", Fr::rand(rng));
         let mut quotient = vec![Fr::zero(); prover.coset_size()];
-        widget.compute_quotient_contribution(&mut prover, &mut Fr::one(), &mut quotient)?;
+        let mut combinator = prover.get_challenge("alpha")?;
+        widget.compute_quotient_contribution(&mut prover, &mut combinator, &mut quotient)?;
         let vi = prover.get_coset_values("vi")?;
         cfg_iter_mut!(quotient)
             .zip(vi.iter())
@@ -303,7 +304,8 @@ mod tests {
         let zeta = Fr::rand(rng);
         prover.add_challenge("zeta", zeta);
         prover.add_challenge("zeta_omega", zeta * prover.domain.generator());
-        let (r, complement) = widget.compute_linear_contribution(&mut prover, &mut Fr::one())?;
+        let mut combinator = prover.get_challenge("alpha")?;
+        let (r, complement) = widget.compute_linear_contribution(&mut prover, &mut combinator)?;
         println!("done");
 
         print!("check equality...");


### PR DESCRIPTION
Fix `lookup` and `range` widgets. 

1. For `lookup` widget,  now both `table_values` and `sorted_values` have `program_width + 1` columns, with the last column storing the table indices. 
2. For `range` widget, add `combinator` to the computation of both the quotient and linear contributions, which was erroneously missing. 